### PR TITLE
fixing jvm handler

### DIFF
--- a/src/xmonkey_curator/handlers/jvm_handler.py
+++ b/src/xmonkey_curator/handlers/jvm_handler.py
@@ -2,6 +2,7 @@ import re
 import os
 import logging
 from ..base_handler import BaseFileHandler
+from ..lexer_utilities import LexerUtilities
 from pygments import lex
 from pygments.lexers import get_lexer_by_name
 


### PR DESCRIPTION
Fixed JVM Handler to include Lexs, and confirmed functionality of GZIP handler as part of archive.

As the testfile expands on an image/g3fax, the class is excluded from scans.